### PR TITLE
Bugfix for PHP 8 & Wordpress 5.9/6.0

### DIFF
--- a/setup/menu-page.php
+++ b/setup/menu-page.php
@@ -150,7 +150,8 @@ function get_snippet($created_at, $accs = '', $paths = '', $signed = false, $wit
 
                     <!-- ===== PHP FOR LOOP CONTENT BEGINS ===== -->
                     <?php
-                    if(count($settings) > 0){
+                    // added (array) to cast $settings as an array for null assertion error in PHP8 and Wordpress 5.9+                     
+                    if(count((array)$settings) > 0) {
 
                         echo '<div class="lit-debug">';
 


### PR DESCRIPTION
Adding this as a fix for the following error:

Warning: count(): Parameter $value must be an array or an object that implements Countable in … on line 1xx in menu-page

Occurs on PHP8 servers. Casting value $setting as an array to quick fix the error. 
